### PR TITLE
Make jenkins-slave.exe work on Server 2012

### DIFF
--- a/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.exe.config
+++ b/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.exe.config
@@ -3,4 +3,8 @@
   <runtime>
     <generatePublisherEvidence enabled="false"/>
   </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" />
+    <supportedRuntime version="v2.0" />
+  </startup>
 </configuration>


### PR DESCRIPTION
Untested, got this from a comment to https://wiki.jenkins-ci.org/display/JENKINS/Windows+slaves+Plugin