### PR TITLE
Update WinSW dependency from 1.18 to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <description>Adds a GUI option to install the JNLP agent as a Windows service</description>
 
   <properties>
-    <winsw.version>2.0.1</winsw.version>
+    <winsw.version>2.0.2</winsw.version>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <description>Adds a GUI option to install the JNLP agent as a Windows service</description>
 
   <properties>
-    <winsw.version>1.18</winsw.version>
+    <winsw.version>2.0.1</winsw.version>
   </properties>
 
   <scm>

--- a/src/main/java/org/jenkinsci/modules/windows_slave_installer/WindowsSlaveInstaller.java
+++ b/src/main/java/org/jenkinsci/modules/windows_slave_installer/WindowsSlaveInstaller.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import static hudson.util.jna.SHELLEXECUTEINFO.*;
 
 /**
+ * Installs agent as a Windows service.
+ * The installer uses <a href="https://github.com/kohsuke/winsw">WinSW</a> as a service wrapper.
  * @author Kohsuke Kawaguchi
  */
 public class WindowsSlaveInstaller extends SlaveInstaller {

--- a/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml
+++ b/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+Copyright (c) 2004-2017, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oleg Nenashev and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,10 @@ THE SOFTWARE.
 
 <!--
   Windows service definition for Jenkins agent.
+  This service is powered by the WinSW project: https://github.com/kohsuke/winsw/
+
+  You can find more information about available options here: https://github.com/kohsuke/winsw/blob/master/doc/xmlConfigFile.md
+  Configuration examples are available here: https://github.com/kohsuke/winsw/tree/master/examples
 
   To uninstall, run "jenkins-slave.exe stop" to stop the service, then "jenkins-slave.exe uninstall" to uninstall the service.
   Both commands don't produce any output if the execution is successful.
@@ -31,7 +35,7 @@ THE SOFTWARE.
 <service>
   <id>@ID@</id>
   <name>@ID@</name>
-  <description>This service runs an agent for Jenkinsautomation server.</description>
+  <description>This service runs an agent for Jenkins automation server.</description>
   <!--
     if you'd like to run Jenkins with a specific version of Java, specify a full path to java.exe.
     The following value assumes that you have java in your PATH.
@@ -46,4 +50,6 @@ THE SOFTWARE.
   <logmode>rotate</logmode>
 
   <onfailure action="restart" />
+  
+  <!-- See referenced examples for more options -->
 </service>

--- a/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml
+++ b/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml
@@ -51,5 +51,21 @@ THE SOFTWARE.
 
   <onfailure action="restart" />
   
+  <!-- 
+    In the case WinSW gets terminated and leaks the process, we want to abort
+    these runaway JAR processes on startup to prevent "Slave is already connected errors" (JENKINS-28492).
+  -->
+  <extensions>
+    <!-- This is a sample configuration for the RunawayProcessKiller extension. -->
+    <extension enabled="true" 
+               className="winsw.Plugins.RunawayProcessKiller.RunawayProcessKillerExtension"
+               id="killOnStartup">
+      <pidfile>%BASE%\jenkins_agent.pid</pidfile>
+      <stopTimeout>5000</stopTimeout>
+      <stopParentFirst>false</stopParentFirst>
+    </extension>
+  </extensions>
+  
   <!-- See referenced examples for more options -->
+  
 </service>


### PR DESCRIPTION
This change updates WinSW to 2.0.1

The update includes many fixes and improvements, the full list is provided in the [WinSW changelog](https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md). There are several issues referenced in Jenkins bugtracker:

* [JENKINS-22692](https://issues.jenkins-ci.org/browse/JENKINS-22692) - Connection reset issues when WinSW gets terminated due to the system shutdown
* [JENKINS-23487](https://issues.jenkins-ci.org/browse/JENKINS-23487)- Support of shared directories in WinSW
* [JENKINS-39231](https://issues.jenkins-ci.org/browse/JENKINS-39231) - Enable Runaway Process Killer by default

It also provides basement for the following fixes:

* [JENKINS-16490](https://issues.jenkins-ci.org/browse/JENKINS-16490) - Auto-upgrade of JNLP agent versions on the slaves
* (Do not recall) Jenkins agent failures in the case of hanging runaway processes

@jenkinsci/code-reviewers  and CC @reviewbybees if somebody is interested