### PR TITLE
Modify the default Agent name to indicate it is a Jenkins agent.

### DIFF
--- a/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml
+++ b/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml
@@ -34,7 +34,7 @@ THE SOFTWARE.
 -->
 <service>
   <id>@ID@</id>
-  <name>@ID@</name>
+  <name>Jenkins agent (@ID@)</name>
   <description>This service runs an agent for Jenkins automation server.</description>
   <!--
     if you'd like to run Jenkins with a specific version of Java, specify a full path to java.exe.


### PR DESCRIPTION
Just for the discussion. The current naming has been introduced in #2 to make the service display names unique, but maybe the current name (`"jenkinsslave-"+slaveRoot.replace(':','_').replace('\\','_').replace('/','_');`) is not very human-readable.

CC @jenkinsci/code-reviewers and @bicschneider