### PR TITLE
[JENKINS-43737] - Update WinSW to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@ Below you can view changelogs for the trunk version of the Windows Agent Install
 This file also provides links to Jenkins versions, which bundle the released versions.
 See [Jenkins changelog](https://jenkins.io/changelog/) for more details.
 
+## 1.9
+
+Release date: (Apr 23, 2017) => Jenkins `TODO`
+
+* [JENKINS-43737](https://issues.jenkins-ci.org/browse/JENKINS-43737) -
+Update to [Windows Service Wrapper 2.1.0](https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md#210) to support new features: `<download>` command with authentication and/or fail on error, Delayed Automatic Start mode.
+
+The new features will not be enabled by default in service configuration files, but they can be configured manually.
+
 ## 1.8 
 
-Release date: (Apr 01, 2017) => Jenkins `TODO`
+Release date: (Apr 01, 2017) => Jenkins 2.53
 
 * [JENKINS-42744](https://issues.jenkins-ci.org/browse/JENKINS-42744) -
 Update to [Windows Service Wrapper 2.0.3](https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md#203)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.19</version>
+    <version>2.25</version>
   </parent>
 
   <groupId>org.jenkins-ci.modules</groupId>
@@ -14,7 +14,7 @@
   <description>Adds a GUI option to install the JNLP agent as a Windows service</description>
 
   <properties>
-    <winsw.version>2.0.3</winsw.version>
+    <winsw.version>2.1.0</winsw.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
This change picks the latest version of WinSW with several enhancements. Main use-case for Jenkins: automatic update of slave.jar files on instances requiring authentication to all Jenkins endpoints.

Changelog:
* [Issue #183](https://github.com/kohsuke/winsw/issues/183) - Add support of the Delayed Automatic Start mode definition in config XML. [More Info](doc/xmlConfigFile.md#delayedautostart). ([PR #205](https://github.com/kohsuke/winsw/pull/205))
* [Issue #126](https://github.com/kohsuke/winsw/issues/126) -  Add support of BASIC and [SSPI](https://en.wikipedia.org/wiki/Security_Support_Provider_Interface) authentication in the `<download>` action. [More Info](https://github.com/kohsuke/winsw/blob/master/doc/xmlConfigFile.md#download).
([PR #194](https://github.com/kohsuke/winsw/pull/194), [PR #203](https://github.com/kohsuke/winsw/pull/203))
* Introduce the `failOnError` option in the `<download>` action. [More Info](https://github.com/kohsuke/winsw/blob/master/doc/xmlConfigFile.md#download). ([PR #195](https://github.com/kohsuke/winsw/pull/195))

Full Diff: https://github.com/kohsuke/winsw/compare/winsw-2.0.3...winsw-2.1.0

@jenkinsci/core @nightman68 @jtnord