### PR TITLE
[JENKINS-43930 & Others] - FindBugs fixes towards 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ See [Jenkins changelog](https://jenkins.io/changelog/) for more details.
 
 ## 1.9
 
-Release date: (Apr 23, 2017) => Jenkins `TODO`
+Release date: (Apr 28, 2017) => Jenkins `TODO`
 
 * [JENKINS-43737](https://issues.jenkins-ci.org/browse/JENKINS-43737) -
-Update to [Windows Service Wrapper 2.1.0](https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md#210) to support new features: `<download>` command with authentication and/or fail on error, Delayed Automatic Start mode.
+Update to [Windows Service Wrapper 2.1.0](https://github.com/kohsuke/winsw/blob/master/CHANGELOG.md#210) to support new features: `<download>` command with authentication, flag for startup failure on `<download>` error, _Delayed Automatic Start_ mode.
+* [JENKINS-42745](https://issues.jenkins-ci.org/browse/JENKINS-42745) -
+Restore compatibility of the `WindowsSlaveInstaller#generateSlaveXml()` method.
+Formally it is a regression in `1.7`, but there is no known usages of this API.
 
 The new features will not be enabled by default in service configuration files, but they can be configured manually.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Update to [Windows Service Wrapper 2.1.0](https://github.com/kohsuke/winsw/blob/
 * [JENKINS-42745](https://issues.jenkins-ci.org/browse/JENKINS-42745) -
 Restore compatibility of the `WindowsSlaveInstaller#generateSlaveXml()` method.
 Formally it is a regression in `1.7`, but there is no known usages of this API.
+* [JENKINS-43930](https://issues.jenkins-ci.org/browse/JENKINS-43930) -
+Prevent fatal file descriptor leak when agent service installer fails to read data from the service `startup.log`.
+* [PR #14](https://github.com/jenkinsci/windows-slave-installer-module/pull/14) -
+Improve logging for restart to the service after the installation completion.
 
 The new features will not be enabled by default in service configuration files, but they can be configured manually.
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.25</version>
+    <version>2.26</version>
   </parent>
 
   <groupId>org.jenkins-ci.modules</groupId>
@@ -14,6 +14,8 @@
   <description>Adds a GUI option to install the JNLP agent as a Windows service</description>
 
   <properties>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
     <winsw.version>2.1.0</winsw.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/org/jenkinsci/modules/windows_slave_installer/SlaveInstallerFactoryImpl.java
+++ b/src/main/java/org/jenkinsci/modules/windows_slave_installer/SlaveInstallerFactoryImpl.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.modules.windows_slave_installer;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.remoting.Channel;
 import jenkins.security.MasterToSlaveCallable;
@@ -26,7 +27,9 @@ public class SlaveInstallerFactoryImpl extends SlaveInstallerFactory {
         return null;
     }
 
+    @SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Remoting does not need it")
     private static final class IsWindows extends MasterToSlaveCallable<Boolean,IOException> {
+        @Override
         public Boolean call() throws IOException {
             return File.pathSeparatorChar==';';
         }

--- a/src/main/java/org/jenkinsci/modules/windows_slave_installer/WindowsSlaveInstaller.java
+++ b/src/main/java/org/jenkinsci/modules/windows_slave_installer/WindowsSlaveInstaller.java
@@ -38,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import static org.jenkinsci.modules.windows_slave_installer.WindowsSlaveInstaller.runElevated;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
@@ -128,8 +129,9 @@ public class WindowsSlaveInstaller extends SlaveInstaller {
                 new File(dir,"jenkins-slave.exe.config"));
 
         // write out the descriptor
+        final String serviceId = generateServiceId(dir.getPath());
         String xml = generateSlaveXml(
-                generateServiceId(dir.getPath()),
+                serviceId,
                 System.getProperty("java.home")+"\\bin\\java.exe", null, 
                 params.buildRunnerArguments().toStringWithQuote(), 
                 Arrays.asList(new MacroValueProvider[] {new AgentURLMacroProvider(params)}));
@@ -159,19 +161,7 @@ public class WindowsSlaveInstaller extends SlaveInstaller {
 //        if(r!=JOptionPane.OK_OPTION)    return;
 
         // let the service start after we close our connection, to avoid conflicts
-        Runtime.getRuntime().addShutdownHook(new Thread("service starter") {
-            public void run() {
-                try {
-                    StreamTaskListener task = StreamTaskListener.fromStdout();
-                    int r = runElevated(agentExe,"start",task,dir);
-                    task.getLogger().println(r==0?"Successfully started":"start service failed. Exit code="+r);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }
-        });
+        Runtime.getRuntime().addShutdownHook(new ServiceStarterThread(agentExe, dir, serviceId));
         
         // TODO: FindBugs: Move to the outer installation logic?
         System.exit(0);
@@ -280,6 +270,32 @@ public class WindowsSlaveInstaller extends SlaveInstaller {
         
         static final Collection<MacroValueProvider> allDefaultProviders() {
             return Arrays.<MacroValueProvider>asList(new AgentURLMacroProvider(null));
+        }
+    }
+    
+    /*package*/ static class ServiceStarterThread extends Thread {
+
+        private final File agentExe;
+        private final File rootDir;
+        private final String serviceId;
+
+        public ServiceStarterThread(@Nonnull File agentExe, @Nonnull File rootDir, @Nonnull String serviceId) {
+            super("Service Starter for " + serviceId);
+            this.agentExe = agentExe;
+            this.rootDir = rootDir;
+            this.serviceId = serviceId;
+        }
+
+        @Override
+        public void run() {
+            try {
+                StreamTaskListener task = StreamTaskListener.fromStdout();
+                int r = runElevated(agentExe, "start", task, rootDir);
+                task.getLogger().println(r == 0 ? "Successfully started" : "Start service failed. Exit code=" + r);
+            } catch (IOException | InterruptedException ex) {
+                // Level is severe, because the process won't be recovered in the service mode
+                LOGGER.log(Level.SEVERE, "Failed to start the service with id=" + serviceId, ex);
+            }
         }
     }
     

--- a/src/main/java/org/jenkinsci/modules/windows_slave_installer/WindowsSlaveInstaller.java
+++ b/src/main/java/org/jenkinsci/modules/windows_slave_installer/WindowsSlaveInstaller.java
@@ -242,7 +242,7 @@ public class WindowsSlaveInstaller extends SlaveInstaller {
                 } 
             }
             // If there is any unknown macro, it will be caught by tests.
-            throw new IOException("Unresolved macros in the XML file: " + String.join(",", unresolvedMacros));
+            throw new IOException("Unresolved macros in the XML file: " + StringUtils.join(unresolvedMacros, ","));
         }
         
         return xml;

--- a/src/main/java/org/jenkinsci/modules/windows_slave_installer/WindowsSlaveInstaller.java
+++ b/src/main/java/org/jenkinsci/modules/windows_slave_installer/WindowsSlaveInstaller.java
@@ -98,9 +98,9 @@ public class WindowsSlaveInstaller extends SlaveInstaller {
         try {
             return Kernel32Utils.waitForExitProcess(sei.hProcess);
         } finally {
-            FileInputStream fin = new FileInputStream(new File(pwd,"redirect.log"));
-            IOUtils.copy(fin,out.getLogger());
-            fin.close();
+            try (FileInputStream fin = new FileInputStream(new File(pwd, "redirect.log"))) {
+                IOUtils.copy(fin,out.getLogger());
+            }
         }
     }
 


### PR DESCRIPTION
- [x] Update Parent POM and increase the FindBugs effort
- [x] Fix file descriptor leak, which may require agent JVM restart to retry the installation. [JENKINS-43930](https://issues.jenkins-ci.org/browse/JENKINS-43930)
- [x] Refactor Restarter thread and improve logging. Makes FindBucs happy about non-static inner classes
- [x] Update changelog

@reviewbybees 