### PR TITLE
[JENKINS-43603] - Add System Property, which allows disabling WinSW auto upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,21 @@ Windows Agent Installer module may be able to automatically upgrade the agent in
 2. Jenkins is expected to automatically upgrade `jenkins-slave.exe` executables if... 
  * The agent is **connected** to the Jenkins master
   * If the agent is not connected, the update will be postponed till the agent connects to the master
- * WinSW executable is located in `REMOTE_ROOT_DIR/jenkins-slave.exe` and writable by the 
+ * WinSW executable is located in `REMOTE_ROOT_DIR/jenkins-slave.exe` and writable by the agent 
  * WinSW executable is writable as well as `REMOTE_ROOT_DIR/jenkins-slave.exe.new` and `REMOTE_ROOT_DIR/jenkins-slave.exe.bak` files
-3. If the upgrade happens, you should be able to see the message in the `Agent log` in the Jenkins Web UI
+3. If the upgrade happens, you should be able to see the message in the `Agent log` in Jenkins Web UI
 4. Once upgrade is done, the changes will be applied on the next Windows service restart
+
+#### Disabling Automatic upgrade
+
+In some cases Jenkins administrators may want to update WinSW to a version higher
+than the version provided by this module.
+By default it is not possible if the executable is named as `jenkins-slave.exe`, 
+because the module performs automatic update.
+
+Starting from version `2.9`, it is possible to disable such automatic upgrades by setting
+the `org.jenkinsci.modules.windows_slave_installer.disableAutoUpdate` System Property
+to `true`.
 
 #### Manual upgrade
 

--- a/src/main/java/org/jenkinsci/modules/windows_slave_installer/SlaveExeUpdater.java
+++ b/src/main/java/org/jenkinsci/modules/windows_slave_installer/SlaveExeUpdater.java
@@ -3,6 +3,7 @@ package org.jenkinsci.modules.windows_slave_installer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Slave;
@@ -15,21 +16,35 @@ import jenkins.model.Jenkins.MasterComputer;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.Callable;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
- * Overwrite <tt>jenkins-slave.exe</tt> by new copy
- *
+ * Overwrite <tt>jenkins-slave.exe</tt> by new copy.
+ * 
  * @author Kohsuke Kawaguchi
  */
 @Extension
+@Restricted(NoExternalUse.class)
+@RestrictedSince("1.9")
 public class SlaveExeUpdater extends ComputerListener {
     /**
      * MD5 checksum of jenkins-slave.exe in our resource
      */
     private volatile String ourCopy;
 
+    /**
+     * Disables automatic update of Windows Service Wrapper on agents.
+     * This option may be useful if this executable is being managed outside Jenkins.
+     * The system property needs to be set up for master only.
+     * @since 1.9
+     */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Should be accessible to System Grrovy Scripts")
+    static boolean DISABLE_AUTOMATIC_UPDATE = Boolean.getBoolean("org.jenkinsci.modules.windows_slave_installer.disableAutoUpdate");
+    
     @Override @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     public void onOnline(Computer c, final TaskListener listener) throws IOException, InterruptedException {
+        if (DISABLE_AUTOMATIC_UPDATE) return;
         if (!(c instanceof SlaveComputer))  return;
 
         final SlaveComputer sc = (SlaveComputer) c;


### PR DESCRIPTION
In some cases WinSW users may want to update WinSW to a higher version, but now it is complicated, because Windows Agent Installer may downgrade the agent using its "automatic upgrade procedure" (just by checksum).

This pull request adds system property, which disables automatic update of the executable. In the future I want something more intelligent (maybe WinSW version provider extension point).

https://issues.jenkins-ci.org/browse/JENKINS-43603

@reviewbybees + @nightman68 since he mentioned this issue in the WinSW bugtracker