### PR TITLE
[JENKINS-46282] - Update WinSW from 2.1.0 to 2.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.modules</groupId>
   <artifactId>windows-slave-installer</artifactId>
-  <version>1.10-SNAPSHOT</version>
+  <version>1.9.1-SNAPSHOT</version>
   <packaging>jenkins-module</packaging>
   <name>Windows agent installer</name>
   <description>Adds a GUI option to install the JNLP agent as a Windows service</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.26</version>
+    <version>2.33</version>
   </parent>
 
   <groupId>org.jenkins-ci.modules</groupId>
@@ -16,7 +16,7 @@
   <properties>
     <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
-    <winsw.version>2.1.0</winsw.version>
+    <winsw.version>2.1.2</winsw.version>
   </properties>
 
   <scm>
@@ -84,6 +84,11 @@
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>slave-installer</artifactId>
       <version>1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>instance-identity</artifactId>
+      <version>1.4</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Fixes [JENKINS-46282](https://issues.jenkins-ci.org/browse/JENKINS-46282), which impacts the default installation.
Also updates Parent POM in the module

Full list of fixes:

- JENKINS-46282 - Runaway Process Killer extension was not using the stopTimeoutMs parameter
- [WinSW Issue #206](https://github.com/kohsuke/winsw/issues/206) - Prevent printing of log entries in the `status` command
- [WinSW Issue #218](https://github.com/kohsuke/winsw/issues/218) - Prevent hanging of the stop executable when its logs are not being drained do the parent process

Full Diff: https://github.com/kohsuke/winsw/compare/winsw-v2.1.0...winsw-v2.1.2

Upstream PR: https://github.com/jenkinsci/jenkins/pull/2987

@reviewbybees 