### PR TITLE
Update jenkins-slave.xml

### DIFF
--- a/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml
+++ b/src/main/resources/org/jenkinsci/modules/windows_slave_installer/jenkins-slave.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     The following value assumes that you have java in your PATH.
   -->
   <executable>@JAVA@</executable>
-  <arguments>-Xrs @VMARGS@ -jar "%BASE%\slave.jar" @ARGS@</arguments>
+  <arguments>-Xrs @VMARGS@ -jar "%BASE%\slave.jar" "@ARGS@"</arguments>
   <!--
     interactive flag causes the empty black Java window to be displayed.
     I'm still debugging this.


### PR DESCRIPTION
I had this service installed in a location like this:
C:\Program Files\Jenkins
And the service wouldn't start because of the space between Program and Files. I changed locally and the service started without problem. Nevertheless when I started the service from Jenkins, the config file is overwritten, losing this minor fix.