### PR TITLE
Use a callable from core rather than defining our own

### DIFF
--- a/src/main/java/org/jenkinsci/modules/windows_slave_installer/SlaveInstallerFactoryImpl.java
+++ b/src/main/java/org/jenkinsci/modules/windows_slave_installer/SlaveInstallerFactoryImpl.java
@@ -1,20 +1,16 @@
 package org.jenkinsci.modules.windows_slave_installer;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
 import hudson.remoting.Channel;
-import jenkins.security.MasterToSlaveCallable;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 import org.jenkinsci.modules.slave_installer.SlaveInstaller;
 import org.jenkinsci.modules.slave_installer.SlaveInstallerFactory;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.io.IOException;
 
-/**
- * @author Kohsuke Kawaguchi
- */
 @Extension
 public class SlaveInstallerFactoryImpl extends SlaveInstallerFactory {
     @Inject
@@ -22,16 +18,11 @@ public class SlaveInstallerFactoryImpl extends SlaveInstallerFactory {
 
     @Override
     public SlaveInstaller createIfApplicable(Channel c) throws IOException, InterruptedException {
-        if (c.call(new IsWindows()))
+        if (new FilePath(c, ".").createLauncher(TaskListener.NULL).isUnix()) {
+            return null;
+        } else {
             return new WindowsSlaveInstaller();
-        return null;
-    }
-
-    @SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID", justification = "Remoting does not need it")
-    private static final class IsWindows extends MasterToSlaveCallable<Boolean,IOException> {
-        @Override
-        public Boolean call() throws IOException {
-            return File.pathSeparatorChar==';';
         }
     }
+
 }


### PR DESCRIPTION
Should save the 164k transfer to a Unix agent’s JAR cache. Tested with a local JNLP agent.