### PR TITLE
Update Windows Service Wrapper from 2.2.0 to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
-    <winsw.version>2.2.0</winsw.version>
+    <winsw.version>2.3.0</winsw.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>


### PR DESCRIPTION
Dependabot cannot comprehend the packaging magic here, because the library is not really a "dependency". Will fix it later, just doing a manual update ATM

