### PR TITLE
Update Windows Service Wrapper from 2.3.0 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
-    <winsw.version>2.3.0</winsw.version>
+    <winsw.version>2.7.0</winsw.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
-    <winsw.version>2.7.0</winsw.version>
+    <winsw.version>2.9.0</winsw.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>


### PR DESCRIPTION
See https://github.com/winsw/winsw/releases for the changelog. There is a lot of changes, most notable ones for the current .NET 2.0 package:

Enhancements:

* Enable TLS 1.1/1.2 in .NET2 and .NET4 packages on Windows 7 and Windows Server 2008 R2
  * https://github.com/jenkinsci/windows-slave-installer-module/pull/25 may be reverted now
* Support 'If-Modified-Since' for download
* Support security descriptor string 

Bug fixes:

* Fix Runaway Process Killer extension so that it does not kill wrong processes with the same PID on startup
* Ensure that environment variables are loaded before resolving configurations
* Fix default domain name in serviceaccount parameter
